### PR TITLE
Maintenance wp6.8

### DIFF
--- a/assets/js/block.js
+++ b/assets/js/block.js
@@ -37,7 +37,8 @@ const lineStyle = ( color = '#fff' ) => {
  * @returns {{}|boolean}
  */
 const convertHtmlToOptions = ( string ) => {
-	if ( ! string.match( /<iframe ([^>]+)\/?>/i ) ) {
+	const iframeMatch = string.match( /<iframe ([^>]+)\/?>/i );
+	if ( ! iframeMatch ) {
 		// error.
 		dispatch( 'core/notices' ).createNotice( 'error', __( 'Sorry, but failed to parse iframe tag.', 'taro-iframe-block' ), {
 			type: 'snackbar',
@@ -51,16 +52,19 @@ const convertHtmlToOptions = ( string ) => {
 	const newAttr = {};
 	const other = [];
 	let updated = false;
-	RegExp.$1.split( ' ' ).forEach( ( part ) => {
+	iframeMatch[ 1 ].match( /[\w-]+="[^"]*"/g ).forEach( ( part ) => {
 		part = part.trim();
 		if ( 'allowfullscreen' === part ) {
 			newAttr.fullscreen = true;
 			updated = true;
 			return true;
-		} else if ( ! part.match( /^([^=]+)=['"]([^'"]+)['"]$/i ) ) {
+		}
+		const match = part.match( /^([^=]+)=['"]([^'"]+)['"]$/i );
+		if ( ! match ) {
 			return true;
-		} else if ( TaroIframeBlockEditor.hasOwnProperty( RegExp.$1 ) ) {
-			newAttr[ RegExp.$1 ] = RegExp.$2;
+		}
+		if ( TaroIframeBlockEditor.hasOwnProperty( match[ 1 ] ) ) {
+			newAttr[ match[ 1 ] ] = match[ 2 ];
 		} else {
 			other.push( part );
 		}

--- a/assets/js/block.js
+++ b/assets/js/block.js
@@ -52,7 +52,7 @@ const convertHtmlToOptions = ( string ) => {
 	const newAttr = {};
 	const other = [];
 	let updated = false;
-	iframeMatch[ 1 ].match( /[\w-]+="[^"]*"/g ).forEach( ( part ) => {
+	iframeMatch[ 1 ].match( /[\w-]+=(?:"[^"]*"|'[^']*')|[\w-]+/g ).forEach( ( part ) => {
 		part = part.trim();
 		if ( 'allowfullscreen' === part ) {
 			newAttr.fullscreen = true;

--- a/assets/js/block.js
+++ b/assets/js/block.js
@@ -83,7 +83,7 @@ const IframeInserter = ( { onConvert } ) => {
 			<TextareaControl label={ __( 'iframe tag', 'taro-iframe-block' ) } value={ html }
 				onChange={ ( newHtml ) => setHtmlState( newHtml ) }
 				help={ __( 'Paste html tag here and convert into options.', 'taro-iframe-block' ) }
-				placeholder={ 'e.g. <iframe src="https://example.com" width="640" height="480" />' } rows={ 4 } />
+				placeholder={ 'e.g. <iframe src="https://example.com" width="640" height="480" />' } rows={ 4 } __nextHasNoMarginBottom={ true } />
 			<Button onClick={ () => {
 				if ( onConvert ) {
 					const newAttributes = convertHtmlToOptions( html );
@@ -154,16 +154,16 @@ registerBlockType( 'taro/iframe-block', {
 			<>
 				<InspectorControls>
 					<PanelBody defaultOpen={ true } title={ __( 'Display Setting', 'taro-iframe-block' ) } >
-						<TextControl type="url" label={ __( 'SRC attribute', 'taro-iframe-block' ) } value={ attributes.src } onChange={ ( src ) => setAttributes( { src } ) } />
-						<TextControl label={ __( 'Width', 'taro-iframe-block' ) } value={ attributes.width } onChange={ ( width ) => setAttributes( { width } ) } />
-						<TextControl label={ __( 'Height', 'taro-iframe-block' ) } value={ attributes.height } onChange={ ( height ) => setAttributes( { height } ) } />
+						<TextControl type="url" label={ __( 'SRC attribute', 'taro-iframe-block' ) } value={ attributes.src } onChange={ ( src ) => setAttributes( { src } ) } __next40pxDefaultSize={ true } __nextHasNoMarginBottom={ true } />
+						<TextControl label={ __( 'Width', 'taro-iframe-block' ) } value={ attributes.width } onChange={ ( width ) => setAttributes( { width } ) } __next40pxDefaultSize={ true } __nextHasNoMarginBottom={ true } />
+						<TextControl label={ __( 'Height', 'taro-iframe-block' ) } value={ attributes.height } onChange={ ( height ) => setAttributes( { height } ) } __next40pxDefaultSize={ true } __nextHasNoMarginBottom={ true } />
 						<ToggleControl checked={ attributes.responsive } label={ __( 'Responsive', 'taro-iframe-block' ) } onChange={ ( responsive ) => setAttributes( { responsive } ) }
-							help={ responsiveHelp } />
-						<ToggleControl checked={ attributes.fullscreen } label={ __( 'Allow Fullscreen', 'taro-iframe-block' ) } onChange={ ( fullscreen ) => setAttributes( { fullscreen } ) } />
+							help={ responsiveHelp } __nextHasNoMarginBottom={ true } />
+						<ToggleControl checked={ attributes.fullscreen } label={ __( 'Allow Fullscreen', 'taro-iframe-block' ) } onChange={ ( fullscreen ) => setAttributes( { fullscreen } ) } __nextHasNoMarginBottom={ true } />
 						<TextControl label={ __( 'Other Attributes', 'taro-iframe-block' ) }
 							placeholder={ 'e.g. id="frame" name="my-map"' }
 							help={ __( 'Add other attribute here.', 'taro-iframe-block' ) }
-							value={ attributes.other } onChange={ ( other ) => setAttributes( { other } ) } />
+							value={ attributes.other } onChange={ ( other ) => setAttributes( { other } ) } __next40pxDefaultSize={ true } __nextHasNoMarginBottom={ true } />
 					</PanelBody>
 					<PanelBody defaultOpen={ false } title={ __( 'Converter', 'taro-iframe-block' ) }>
 						<IframeInserter onConvert={ ( newAttr ) => setAttributes( newAttr ) } />

--- a/taro-iframe-block.php
+++ b/taro-iframe-block.php
@@ -180,6 +180,9 @@ function taro_iframe_callback( $attributes = [], $content = '' ) {
 					'referrerpolicy'  => [],
 					'title'           => [],
 					'style'           => [],
+					'name'            => [],
+					'tabindex'        => [],
+					'csp'             => [],
 				],
 			] )
 		);

--- a/taro-iframe-block.php
+++ b/taro-iframe-block.php
@@ -178,8 +178,8 @@ function taro_iframe_callback( $attributes = [], $content = '' ) {
 					'frameborder'     => [],
 					'sandbox'         => [],
 					'referrerpolicy'  => [],
-					'title'			  => [],
-					'style'			  => [],
+					'title'           => [],
+					'style'           => [],
 				],
 			] )
 		);

--- a/taro-iframe-block.php
+++ b/taro-iframe-block.php
@@ -177,6 +177,9 @@ function taro_iframe_callback( $attributes = [], $content = '' ) {
 					'allow'           => [],
 					'frameborder'     => [],
 					'sandbox'         => [],
+					'referrerpolicy'  => [],
+					'title'			  => [],
+					'style'			  => [],
 				],
 			] )
 		);


### PR DESCRIPTION
最初にdeprecationsを直しました。古いワードプレスを使っても問題ないと思います。

The problem was caused by splitting the attributes based on a single space " ". This is bad, because the title and potentially other attributes can have values that contain spaces as well. I fixed it using regex. On the front end there where no bugs, but attributes where filtered by name, so I added "title", "style" and "referrerpolicy".

To confirm whether it works, I added a style attribute with a big red border to the "Other Attributes" section of the block editor and saved it. It applied the styling both in the editor and on the live page. On the live page I used "inspect" to make sure it contained the title attribute as well.

この問題は、属性をスペース「 」1つで分割していたことが原因でした。これは、タイトル属性やその他の属性にもスペースを含む値が含まれる可能性があるため、好ましくありません。正規表現を使用して修正しました。フロントエンドではバグはありませんでしたが、属性は名前でフィルタリングされていたため、「title」、「style」、「referrerpolicy」を追加しました。

動作を確認するために、ブロックエディターの「その他の属性」セクションに大きな赤い枠線の付いたスタイル属性を追加し、保存しました。エディターとライブページの両方でスタイルが適用されました。ライブページでは「inspect」を使用して、タイトル属性も含まれていることを確認しました。

<img width="1710" alt="screenshot1" src="https://github.com/user-attachments/assets/39777ee9-bafe-46f4-8de9-ab2276ba5d55" />
<img width="1710" alt="screenshot2" src="https://github.com/user-attachments/assets/d1e3655d-f5dd-4e76-b1f5-6ea556fff3c6" />
<img width="1710" alt="screenshot3" src="https://github.com/user-attachments/assets/3c5fe980-d14d-40f2-b342-537515c8b869" />
