### PR TITLE
Use npm ci --ignore-scripts in CI workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,7 +33,7 @@ jobs:
           node-version-file: '.node-version'
 
       - name: Install npm dependencies
-        run: npm install
+        run: npm ci --ignore-scripts
 
       - name: Build Assets
         run: npm run package


### PR DESCRIPTION
## Summary
- Replace `npm install` with `npm ci --ignore-scripts` in deploy workflow
- Prevents execution of postinstall/lifecycle scripts during CI, mitigating supply chain attacks
- No functional impact: CI doesn't need husky hooks or other lifecycle scripts

## Test plan
- [ ] Deploy workflow still builds correctly on next release

🤖 Generated with [Claude Code](https://claude.com/claude-code)