### PR TITLE
Add custom build_command to Playground preview

### DIFF
--- a/.github/workflows/playground-preview-build.yml
+++ b/.github/workflows/playground-preview-build.yml
@@ -13,3 +13,5 @@ jobs:
       contains(github.event.pull_request.labels.*.name, 'playground') &&
       (github.event.action != 'labeled' || github.event.label.name == 'playground')
     uses: tarosky/workflows/.github/workflows/playground-preview-build.yml@main
+    with:
+      build_command: 'npm ci --ignore-scripts && npm run package'


### PR DESCRIPTION
## Summary
- Add custom `build_command` to Playground preview build workflow
- Uses `npm ci --ignore-scripts && npm run package` (no composer needed for production)
- Ensures Playground preview builds correctly without unnecessary composer install

## Test plan
- [ ] Create a test PR, add `playground` label, verify preview link appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)